### PR TITLE
bugfix: Modify upload and submit  buttons are only available to be clicked when needed.

### DIFF
--- a/src/components/InputFileForm/index.js
+++ b/src/components/InputFileForm/index.js
@@ -4,25 +4,61 @@ import { AudioProgressbar } from '../AudioProgressbar';
 
 class InputFileForm extends Component {
   render() {
-    const { onChange, onClick, progress } = this.props;
-    return (
-      <Positioner>
-        <ButtonLayout>
-          <form>
-            <label htmlFor="file-upload">UPLOAD</label>
-            <StyledInput
-              type="file"
-              name="upload"
-              id="file-upload"
-              onChange={onChange}
-              accept=".wav"
-            />
-            <StyledInput
-              id="file-submit"
+    const { file, onChange, onClick, progress } = this.props;
+      const submit = () => {
+        if(!file||progress){
+          return(
+            <StyledInput 
+              id="file-submit-block"
               type="button"
               value="SUBMIT"
               onClick={onClick}
+              disabled 
             />
+          )
+        }else{
+          return(
+            <StyledInput 
+              id="file-submit"
+              type="button"
+              value="SUBMIT"
+              onClick={onClick} 
+            />
+          )
+        }
+      }
+    const fileUpload = () =>{
+      if(progress){
+        return(
+          <StyledInput
+            type="file"
+            name="upload"
+            id="file-upload-block"
+            onChange={onChange}
+            accept=".wav"
+            disabled
+          />
+        )
+      }else{
+        return(
+          <StyledInput
+            type="file"
+            name="upload"
+            id="file-upload"
+            onChange={onChange}
+            accept=".wav"
+          />
+        )
+      }
+    }
+
+    return (
+      <Positioner>
+        <ButtonLayout id={progress ? 'block' : 'hover'}>
+          <form>
+            <label htmlFor="file-upload">UPLOAD</label>
+            {fileUpload()}
+            {submit()}
           </form>
           <AudioProgressbar className={progress ? '-stt ' : 'none'} />
         </ButtonLayout>

--- a/src/containers/TestContainer.js
+++ b/src/containers/TestContainer.js
@@ -60,6 +60,7 @@ class TestContainer extends Component {
       <div>
         <AudioContainer file={file} />
         <InputFileForm
+          file={file}
           progress={progress}
           onChange={this.onChangeFile}
           onClick={this.onFileSubmit}

--- a/src/styledComponents/StyledLayout/index.jsx
+++ b/src/styledComponents/StyledLayout/index.jsx
@@ -20,7 +20,8 @@ const ButtonLayout = styled.div`
     form {
       display: inherit;
     }
-
+  }
+  &#hover {
     label {
       ${shadow(1)};
       border-radius: 0.2em;
@@ -39,6 +40,20 @@ const ButtonLayout = styled.div`
       :active {
         background-color: ${oc.cyan[3]};
       }
+    }
+  }
+  &#block {
+    label {
+      ${shadow(1)};
+      border-radius: 0.2em;
+      background-color: ${oc.cyan[3]};
+      display: inherit;
+      padding: 0.6em 0.8em;
+      text-align: center;
+      font-size: 1.3em;
+      margin-right: 2%;
+      font-weight: bold;
+      color: ${oc.gray[6]};
     }
   }
 `;
@@ -188,6 +203,10 @@ const StyledInput = styled.input`
     display: none;
   }
 
+  &#file-upload-block {
+    display: none;
+  }
+
   &#file-submit {
     font-weight: bold;
     background-color: ${oc.cyan[3]};
@@ -204,6 +223,16 @@ const StyledInput = styled.input`
     :active {
       background-color: ${oc.cyan[3]};
     }
+  }
+
+  &#file-submit-block {
+    font-weight: bold;
+    background-color: ${oc.cyan[3]};
+    border-radius: 0.2em;
+    margin-right: 2%;
+    display: inherit;
+    padding: 0.6em 0.8em;
+    font-size: 1.2em;
   }
 `;
 


### PR DESCRIPTION
We found a problem.
The problem occurred when the submit button was clicked without a file.
and I could click the submit button when using the speech to text function.
It made a problem

I fixed it like this.
1. If the file is not on the state then we will can't click submit button
2. We can't click upload and submit button while working speech to text function

